### PR TITLE
TypeScript/Angular2 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ module.exports = function(THREE) {
 
 			function isASCII( data ) {
 
-				var header = parseHeader( bin2str( data ) );
+				var header = parseHeader(bin2strHeader(data));
 				return header.format === 'ascii';
 
 			}
@@ -52,6 +52,22 @@ module.exports = function(THREE) {
 
 					str += String.fromCharCode( array_buffer[ i ] ); // implicitly assumes little-endian
 
+				}
+
+				return str;
+
+			}
+
+			function bin2strHeader(buf) { // decode only the file header
+
+				var array_buffer = new Uint8Array(buf);
+				var patternHeader = /ply([\s\S]*)end_header\s/;
+				var str = '';
+				var i = 0;
+
+				while (!patternHeader.exec(str)) {
+					str += String.fromCharCode(array_buffer[i]); // implicitly assumes little-endian
+					i++;
 				}
 
 				return str;
@@ -431,7 +447,7 @@ module.exports = function(THREE) {
 					colors : []
 				};
 
-				var header = parseHeader( bin2str( data ) );
+				var header = parseHeader(bin2strHeader(data));
 				var little_endian = ( header.format === 'binary_little_endian' );
 				var body = new DataView( data, header.headerLength );
 				var result, loc = 0;

--- a/index.js
+++ b/index.js
@@ -474,4 +474,6 @@ module.exports = function(THREE) {
 		}
 
 	};
+
+	return THREE.PLYLoader;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-ply-loader",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "NodeJS wrapper for Three.js' PLYLoader function",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-ply-loader",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "NodeJS wrapper for Three.js' PLYLoader function",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This fix allows to use the PLYLoader easily from withing TypeScript/Angular (at least when using CommonJS `require` instead of modern ES6 `import`):
```typescript
let THREE = require('three')
let PLYLoader = require('three-ply-loader')(THREE)
```
The problem when using `THREE.PLYLoader` were undeclared variable exceptions because type declarations of the `THREE` object augmented with `PLYLoader` were missing.

This also aligns the usage to the same fashion as done in the the STL Loader:
https://github.com/enspiral-cherubi/three-stl-loader/blob/master/index.js#L287